### PR TITLE
Kalliope 0.6

### DIFF
--- a/dna.yml
+++ b/dna.yml
@@ -3,7 +3,7 @@ type: "neuron"
 author: "Bacardi55"
 
 kalliope_supported_version:
-    - 0.5
+    - 0.6
 
 tags:
 - "system"

--- a/install.yml
+++ b/install.yml
@@ -7,5 +7,5 @@
   tasks:
     - name: "Install pip dependencies"
       pip:
-        name: psutil
-        version: 5.1.3
+        name: "psutil"
+        executable: pip3


### PR DESCRIPTION
this is the fix for kalliope 0.6 because the old version doesn't work in pip anymore, so you have to switch to pip3
I'm testing them. She works at home.
Sincerely